### PR TITLE
禁用相邻页内容的垂直均匀分布排版

### DIFF
--- a/jnuthesis.dtx
+++ b/jnuthesis.dtx
@@ -2147,6 +2147,18 @@ December\fi
 \fi
 %    \end{macrocode}
 %
+% \subsection{垂直均匀分布}
+%
+% 江南大学有些时候极其重视段落、标题之间的垂直间距。很不幸这有时会与|book|类
+% 的默认设置\cs{\flushbottom}相冲突，表现为相邻的偶数页与奇数页内容总高度
+% 相差较大时，为使左右两页的高度相同，较矮的一页段落会被拉开很多，视觉上造成一种
+% 该处段落垂直间距设置错误的感觉。Microsoft Word的默认行为与\cs{\raggedbottom}
+% 相同，因此我们覆盖掉\LaTeX{}的默认设置。
+%
+%    \begin{macrocode}
+\raggedbottom
+%    \end{macrocode}
+%
 % \subsection{字体设置}
 %
 % 首先根据文档选项选择正确的中文字体名称。


### PR DESCRIPTION
如题，因为效果与Word一样难看，所以除非老师强烈要求，不合并。

## Before

![flushbottom](https://cloud.githubusercontent.com/assets/1175567/26281011/be4cfe6e-3e1a-11e7-8f3f-3abcebcaff9d.png)


## After

![raggedbottom](https://cloud.githubusercontent.com/assets/1175567/26281012/c5e60fbc-3e1a-11e7-96be-ff0adefbecc1.png)
